### PR TITLE
Refactor Docker Configuration for Improved Development Workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  graphdb:
+    image: ontotext/graphdb:9.11.2-se
+    ports:
+      - "7200:7200"
+    volumes:
+      - graphdb-data:/opt/graphdb/home
+
+  spalod-backend:
+    build:
+      context: .
+      dockerfile: spring.Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - graphdb
+
+  spalod-frontend:
+    build:
+      context: .
+      dockerfile: vue.Dockerfile
+    ports:
+      - "8081:8081"
+    depends_on:
+      - spalod-backend
+
+volumes:
+  graphdb-data:

--- a/spring.Dockerfile
+++ b/spring.Dockerfile
@@ -1,0 +1,41 @@
+FROM maven:3.8.6-openjdk-18 as build
+
+WORKDIR /app
+
+# Install custom dependencies first
+COPY libs/pisemantic-1.0-SNAPSHOT.jar /app/libs/pisemantic-1.0-SNAPSHOT.jar
+COPY libs/pitools-1.0-SNAPSHOT.jar /app/libs/pitools-1.0-SNAPSHOT.jar
+COPY pom.xml /app/pom.xml
+
+# Install pisemantic
+RUN mvn install:install-file \
+    -Dfile=/app/libs/pisemantic-1.0-SNAPSHOT.jar \
+    -DgroupId=info.ponciano.lab \
+    -DartifactId=pisemantic \
+    -Dversion=1.0 \
+    -Dpackaging=jar \
+    -DpomFile=/app/pom.xml
+
+# Install pitools
+RUN mvn install:install-file \
+    -Dfile=/app/libs/pitools-1.0-SNAPSHOT.jar \
+    -DgroupId=info.ponciano.lab \
+    -DartifactId=pitools \
+    -Dversion=1.0-SNAPSHOT \
+    -Dpackaging=jar \
+    -DpomFile=/app/pom.xml
+
+# Copy the rest of the application's source code
+COPY src /app/src
+COPY application.yml /app/src/main/resources/
+
+# Build and skip tests to speed up the process
+RUN mvn package -DskipTests
+
+# Final stage to prepare the runtime image
+FROM openjdk:18-jdk-slim
+WORKDIR /app
+COPY --from=build /app/target/spalod-0.0.1-SNAPSHOT.jar /app/
+
+# Set the default command to run the jar
+CMD ["java", "-jar", "spalod-0.0.1-SNAPSHOT.jar"]

--- a/vue.Dockerfile
+++ b/vue.Dockerfile
@@ -1,0 +1,17 @@
+FROM node:16
+
+WORKDIR /app
+
+# Copy the package.json and install dependencies
+COPY src/main/vue_js/spalod/package*.json ./
+RUN npm install
+
+# Copy the rest of the frontend source code
+COPY src/main/vue_js/spalod .
+
+# Build the application
+RUN npm run build
+
+# Serve the app using serve
+RUN npm install -g serve
+CMD ["serve", "-s", "dist", "-l", "8081"]


### PR DESCRIPTION
I've refactored the Docker setup to streamline the development process and reduce the complexity of deployment. Here are the key changes:

1. GraphDB Integration: Switched to using an official pre-built Docker image for GraphDB, eliminating the need for manual installation.
2. Spring Backend: Introduced spring.Dockerfile to handle dependency installation and serve the application on port 8080.
3. Vue Frontend: Created vue.Dockerfile to manage frontend dependencies and serve it on port 8081.

These changes simplify the startup process to a single command: `docker compose up` from the root directory, replacing the previous approach that relied on the `spalod.sh` script.

Benefits are:
1. Reduced Image Size: The new Docker images are smaller and less complex, utilizing lighter base images compared to the previous Ubuntu-based setup.
2. Simplified Management: By segmenting the services, each component can be managed more efficiently, and issues can be isolated more quickly.

While the updated configuration is operational and has shown no errors in initial testing, it is not yet ready for production. The setup may not cover all operational scenarios or be fully optimized for performance.

I am seeking feedback on possible improvements or overlooked aspects!